### PR TITLE
Fix application form link for training week

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .quarto/
 _site/
 .DS_Store
+
+/.quarto/

--- a/pre-training.qmd
+++ b/pre-training.qmd
@@ -15,7 +15,7 @@ tbl-colwidths: [35,65]
 
 This week-long in-person workshop provide a practical introduction to outbreak data analysis using R packages developed by the Epiverse-TRACE initiative.
 
-Fill out this [form to apply](https://forms.office.com/Pages/DesignPageV2.aspx?subpage=design&token=09a01e121b9447dbbec65057eece25af&id=oaKtcild7U6xlPh0V3cUnuJi79dolFdJoZ1qVAcSQu9UMVNUTzdEWk9CNTJMNFZNQlM2UlQ4UDNHVi4u) for this training. Application deadline is **Friday 27th September**. Places are limited and will be given on a first come, first served basis. There is no registration fee and limited funds are available for travel and local expenses. Application data will be kept confidential and may only be published in aggregated and anonymised form in Epiverse-TRACE outreach reports. If you have questions about the training, please send an email to [andree.valle-campos\@lshtm.ac.uk]() or [lshad35\@lshtm.ac.uk]().
+Fill out this [form to apply](https://forms.office.com/e/MdHMYMKmC7) for this training. Application deadline is **Friday 27th September**. Places are limited and will be given on a first come, first served basis. There is no registration fee and limited funds are available for travel and local expenses. Application data will be kept confidential and may only be published in aggregated and anonymised form in Epiverse-TRACE outreach reports. If you have questions about the training, please send an email to [andree.valle-campos\@lshtm.ac.uk]() or [lshad35\@lshtm.ac.uk]().
 
 ## Course content
 


### PR DESCRIPTION
PR to fix the application link to pre-summit training. 

The current one redirects to the edit version and requires LSHTM authentication.